### PR TITLE
fix: fix when rich text getting stripped out in overflow element

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "line-truncation",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "scripts": {
     "build": "rollup -c"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ let ellipsisCharacter = '\u2026';
  * @param truncateHeight The desired height.
  * @param options The passed in options by the user.
  */
-export function truncate(rootElement, lines, ellipsis = ellipsisCharacter, callback = val => {}) {
+export function truncate(rootElement, lines, ellipsis = ellipsisCharacter, callback = val => { }) {
   if (!lines || !rootElement) {
     return;
   }
@@ -91,9 +91,9 @@ export function getLineHeight(element) {
   if (lineHeightComputedStyle === 'normal') {
     // Define a fallback for 'normal' value with 1.2 as a line-height
     // https://www.w3.org/TR/CSS21/visudet.html#normal-block
-    return parseFloat(window.getComputedStyle(element).fontSize, 10) * 1.2;
+    return parseFloat(window.getComputedStyle(element).fontSize) * 1.2;
   } else {
-    return parseFloat(lineHeightComputedStyle, 10);
+    return parseFloat(lineHeightComputedStyle);
   }
 }
 
@@ -212,11 +212,12 @@ function truncateTextNode(textNode, rootElement, truncateHeight) {
 
 /**
  * Truncate Text Node by remove the last character
- * @param textNode The child node in the root element.
+ * @param textNode The text node of last element of current root element.
+ * @param lastElement The last element of current root element.
  * @param rootElement The root node.
  * @param truncateHeight The desired height.
  */
-function truncateTextNodeByCharacter(textNode, rootElement, truncateHeight) {
+function truncateTextNodeByCharacter(textNode, lastElement, rootElement, truncateHeight) {
   let currentLength = textNode.textContent.length;
 
   while (currentLength > 0) {
@@ -233,7 +234,7 @@ function truncateTextNodeByCharacter(textNode, rootElement, truncateHeight) {
 
     textNode.textContent = textNode.textContent.substring(0, currentLength - 1);
     // Add ellipsis before comparing height
-    textNode.insertAdjacentHTML(
+    lastElement.insertAdjacentHTML(
       'beforeend',
       `<span class="trunk-char">${ellipsisCharacter}</span>`
     );
@@ -241,7 +242,7 @@ function truncateTextNodeByCharacter(textNode, rootElement, truncateHeight) {
       break;
     }
     // Take out ellipsis character for the next iteration
-    textNode.removeChild(textNode.lastChild);
+    lastElement.removeChild(lastElement.lastChild);
     currentLength = textNode.textContent.length;
   }
   return true;
@@ -263,7 +264,7 @@ function addEllipsis(rootElement, truncateHeight) {
 
   if (getContentHeight(rootElement) > truncateHeight) {
     lastTextChildElement.removeChild(lastTextChildElement.lastChild); // remove the ellipsis that we just inserted
-    truncateTextNodeByCharacter(lastTextChildElement, rootElement, truncateHeight);
+    truncateTextNodeByCharacter(lastTextChildElement.lastChild, lastTextChildElement, rootElement, truncateHeight);
   }
 }
 


### PR DESCRIPTION
This is library fix for https://github.com/DiZhou92/ngx-line-truncation/issues/27

before fix:
![Screen Shot 2020-06-21 at 9 22 36 PM](https://user-images.githubusercontent.com/8729723/85240405-0f6fa580-b406-11ea-8d0e-9570929ac638.png)
after fix:
![Screen Shot 2020-06-21 at 9 23 04 PM](https://user-images.githubusercontent.com/8729723/85240412-14ccf000-b406-11ea-8242-65d3ac7374fb.png)

testing HTML elements (run in Angular environment)
![Screen Shot 2020-06-21 at 9 23 15 PM](https://user-images.githubusercontent.com/8729723/85240652-e996d080-b406-11ea-914e-c2544ea95c8c.png)
![Screen Shot 2020-06-21 at 9 23 27 PM](https://user-images.githubusercontent.com/8729723/85240658-ed2a5780-b406-11ea-98dc-6d0a8b03d8f1.png)
